### PR TITLE
Rework networking logic and some miscellaneous code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cd synology-pihole
 ## Usage
 *Synology-pihole* requires `sudo` rights. Use the following command to invoke *synology-pihole* from the command line.
 
-```console
+```
 sudo ./syno_pihole.sh [OPTIONS] [PARAMETERS] COMMAND
 ```
 
@@ -101,7 +101,7 @@ sudo ./syno_pihole.sh update
 | **`network`**  | Creates or recreates virtual network |
 | **`update`**   | Updates an existing Pi-hole Docker container |
 
-In the addition, the following options are available.
+In addition, the following options are available.
 
 | Option | Alias      | Parameter  | Description |
 |--------|------------|------------|-------------|
@@ -114,19 +114,20 @@ In the addition, the following options are available.
 | Variable          | Parameter       | Required | Example               | Description |
 |-------------------|-----------------|----------|----------------------|-------------|
 | `PIHOLE_IP`       | -i, --ip        | `Yes`    | `192.168.0.250`      | Static IP address of Pi-hole, ensure this IP address is available |
-| `SUBNET`          | -s, --subnet    | `No`     | `192.168.0.0/24`     | Subnet of the virtual network for Pi-hole (auto-detected if omitted) |
-| `GATEWAY`         | -g, --gateway   | `No`     | `192.168.0.1`        | Gateway of the virtual network for Pi-hole (auto-detected if omitted) |
-| `IP_RANGE`        | -r, --range     | `No`     | `192.168.0.250/30`   | IP range with CIDR notation of the virtual network for Pi-hole (defaults to `PIHOLE_IP/30`) |
-| `VLAN_NAME`       | -v, --vlan      | `No`     | `macvlan0`           | Name of the virtual network for Pi-hole (defaults to `macvlan0`) |
-| `INTERFACE`       | -n, --interface | `No`     | `eth0`               | Physical interface of the virtual network for Pi-hole (auto-detected if omitted) |
-| `MAC_ADDRESS`     | -m, --mac       | `No`     | `70:d9:5a:70:99:cd`  | Unicast MAC address of Pi-hole (randomized if omitted) |
-| `DOMAIN_NAME`     | -d, --domain    | `No`     | `pihole.example.com` | Fully qualified domain name for Pi-hole |
-| `PIHOLE_HOSTNAME` | -H, --host      | `No`     | `pihole`             | Hostname of Pi-hole (defaults to `pihole`) |
-| `TIMEZONE`        | -t, --timezone  | `No`     | `Europe/Amsterdam`   | Timezone for Pi-hole (see [Wikipedia][timezone_list] for an overview, auto-detected if omitted) |
+| `INTERFACE`       | -n, --interface | `No`     | `eth0`               | Host network interface to the subnet, auto-detected if omitted |
+| `SUBNET`          | -s, --subnet    | `No`     | `192.168.0.0/24`     | CIDR notated subnet the Pi-Hole will join, auto-detected if omitted |
+| `GATEWAY`         | -g, --gateway   | `No`     | `192.168.0.1`        | Subnet gateway router address (see --subnet), auto-detected if omitted |
+| `HOST_IP`         | --host-ip       | `No`     | `192.168.0.3`        | New host address for communicating with Pi-hole via macvlan bridge interface. By default the lowest address starting at the first (not the Pi-hole address) of the Docker network range (see --range) is used |
+| `IP_RANGE`        | -r, --range     | `No`     | `192.168.0.250/30`   | CIDR notated address range for Docker to assign to containers attached to the created 'Docker macvlan Network', defaults to `PIHOLE_IP/32` |
+| `VLAN_NAME`       | -v, --vlan      | `No`     | `macvlan0`           | Name assigned to the generated macvlan interface on the host to enable container <-> host communication (defaults to `macvlan0`) |
+| `MAC_ADDRESS`     | -m, --mac       | `No`     | `70:d9:5a:70:99:cd`  | Unicast MAC to assign Pi-hole, randomized if omitted |
+| `DOMAIN_NAME`     | -d, --domain    | `No`     | `example.com` | Fully qualified domain of the subnet |
+| `PIHOLE_HOSTNAME` | -H, --host      | `No`     | `pihole`             | Hostname of Pi-hole, defaults to `pihole` |
+| `TIMEZONE`        | -t, --timezone  | `No`     | `Europe/Amsterdam`   | Local Timezone (see [Wikipedia][timezone_list] for an overview, auto-detected if omitted) |
 | `DNS1`            | --DNS1          | `No`     | `1.1.1.1`            | Primary DNS provider to be used by Pi-hole (see this [list][upstream_dns] for typical providers) |
 | `DNS2`            | --DNS2          | `No`     | `1.0.0.1`            | Alternative DNS provider to be used by Pi-hole |
-| `DATA_PATH`       | --path          | `No`     | `./data`             | Path where to store your Pi-hole data (defaults to `./data`) |
-| `WEBPASSWORD`     | -p, --password  | `No`     | `password`           | Password for the Pi-hole admin (prompted for when omitted) |
+| `DATA_PATH`       | --path          | `No`     | `./data`             | Host data location path for Pi-hole, defaults to `./data` |
+| `WEBPASSWORD`     | -p, --password  | `No`     | `password`           | Password for the Pi-hole administrative web interface (prompted for when omitted) |
 
 ### Scheduled Tasks
 #### Updating Pi-Hole to the Latest Version
@@ -139,10 +140,10 @@ It is recommended to schedule a task to ensure Pi-hole uses the latest  version 
     /bin/sh /path/to/your/script/syno_pihole.sh update -l /var/log/syno_pihole.log
     ```
 
-#### Ensuring the Virtual Network is Available After Reboot
-By default, Docker containers are automatically restarted after a system reboot. However, the virtual network setup by `synology-pihole` is lost after a system reboot and/or update. Similar to the instructions in the previous paragraph, you can setup a task to automatically recreate the virtual network during the boot process of your Synology NAS. Follow these steps to do so.
+#### Ensuring the Host <-> Container Bridge Interface is Available After Reboot
+By default, Docker containers are automatically restarted after a system reboot. However, the macvlan bridge interface setup by `synology-pihole` is lost after a system reboot and/or update. Similar to the instructions in the previous paragraph, you can setup a task to automatically recreate it during the boot process of your Synology NAS. Follow these steps to do so.
 1. Access `Task Scheduler` via `Control Panel ➡ Task Scheduler` in DSM. 
-2. Now click on `Create ➡ Triggered Task ➡ User-defined script` to create a custom script. Give the task a familiar name in the tab `General`, such as `Recreate Pi-hole network`.
+2. Now click on `Create ➡ Triggered Task ➡ User-defined script` to create a custom script. Give the task a familiar name in the tab `General`, such as `Recreate Pi-hole Bridge Interface`.
 3. In the same screen, select `root` as user and `Boot-up` as event.
 4. Finally, enter the following script in the user-defined script section of the `Task Settings` tab. Be sure to update `/path/to/your/script/`. The optional instruction `-l /var/log/syno_pihole.log` copies all messages to a log file. The option `--force` is required to avoid the script asking for user confirmation.
     ```console
@@ -150,7 +151,7 @@ By default, Docker containers are automatically restarted after a system reboot.
     ```
 
 ### Configuration
-The Pi-hole [FAQ][pihole_dns] describes various options on how to configure Pi-hole as DNS server. The portal of Pi-hole is available by navigating to `http://ip_address/admin/` (replacing `ip_address` with the correct IP address).
+The Pi-hole [FAQ][pihole_dns] describes various options on how to configure the Pi-hole DNS server. The Pi-hole administor web interface is available by navigating to `http://ip_address/admin/` (replacing `ip_address` with the correct IP address).
 
 
 ## Contributing

--- a/sample.env
+++ b/sample.env
@@ -1,10 +1,11 @@
 # Required network settings
-PIHOLE_IP=192.168.0.250         # Static IP address of Pi-hole, ensure this IP is available and within your subnet
+PIHOLE_IP=192.168.0.250         # Static IP address of Pi-hole, ensure this IP is available and within your network subnet
 
 # Optional network settings
 SUBNET=192.168.0.0/24           # Auto-detected on your Synology NAS if omitted
 GATEWAY=192.168.0.1             # Auto-detected on your Synology NAS if omitted
-IP_RANGE=192.168.0.248/30       # Defaults to PIHOLE_IP/30 if omitted (four IPs is the minimum)
+HOST_IP=192.168.0.249			# Defaults to first address not PIHOLE_IP starting at lowest address of IP_RANGE
+IP_RANGE=192.168.0.248/30       # Defaults to PIHOLE_IP/32 if omitted
 VLAN_NAME=macvlan0              # Defaults to 'macvlan0' if omitted
 INTERFACE=eth0                  # Auto-detected on your Synology NAS if omitted       
 MAC_ADDRESS=70:d9:5a:70:99:cd   # Unicast MAC address of Pi-hole, randomized if omitted

--- a/syno_pihole.sh
+++ b/syno_pihole.sh
@@ -152,8 +152,8 @@ is_valid_log_file() {
 
 # Returns 0 (successful) if version string complies with expected format
 is_valid_version() {
-    local IP_VERSION='([0-9]+\.)?([0-9]+\.)?(\*|[0-9]+)'
-    [[ $1 =~ ^$IP_VERSION$ ]] && return 0 || return 1
+    local IP_VERSION='^([0-9]+\.)?([0-9]+\.)?(\*|[0-9]+)$'
+    [[ $1 =~ $IP_VERSION ]] && return 0 || return 1
 }
 
 # Returns 0 (successful) if an IPv4 address complies with expected format
@@ -203,6 +203,7 @@ function is_ip_in_range() {
 # Detects available versions for Pi-hole
 detect_available_versions() {
     # Detect latest available stable Pi-hole version (ignores release candidates)
+    # Repository has stated FTL is the leading developement release version listed as latest.
     if [ -z "$TARGET_PIHOLE_VERSION" ] ; then
         TARGET_PIHOLE_VERSION=$(curl -s "$GITHUB_API_PIHOLE" | grep "tag_name" | egrep -o "[0-9]+.[0-9]+.[0-9]+")
 
@@ -389,7 +390,8 @@ define_pihole_versions() {
     print_status "Detecting current and available Pi-hole versions"
 
     # Detect current Pi-hole version (should comply with 'version.release.modification')
-    PIHOLE_VERSION=$(docker exec -it "$PIHOLE_CONTAINER" pihole -v 2>/dev/null | grep 'Pi-hole' | awk '{print $4}' \
+    # Repository has stated FTL is the leading developement release version listed as latest.
+    PIHOLE_VERSION=$(docker exec "$PIHOLE_CONTAINER" pihole -v 2>/dev/null | grep 'FTL' | awk '{print $4}' \
         | cut -c2-)
     is_valid_version "$PIHOLE_VERSION"
     [ $? == 1 ] && PIHOLE_VERSION=''


### PR DESCRIPTION
Update syno_pihole.sh

This patch reworks the network logic of the script, making a distinction between a CIDR notated range (by convenience) of addresses and an actual IPv4 subnet which has a (all ones host identifier) broadcast address. Conflating a range of addresses in CIDR notation within a (LAN) subnet with an actual subnet seems to be the reason for the original script logic.

This patch considers the PARAM_IP_RANGE parameter to designate a pool of addresses reserved for Docker to use in its generated Docker macvlan network called 'synology-pihole_macvlan' – as is indicated by the use of PARAM_IP_RANGE in the docker-compose.yml file. In the same way the network DHCP server reserves a pool of addresses, this range helps avoid address collisions on the network, especially with the DHCP server. Docker should allocate any container attached to the synology-pihole_macvlan network an address from this pool if a static address (PARAM_PIHOLE_IP) were not already specified.

While the Docker generated macvlan synology-pihole_macvlan uses PARAM_IP_RANGE to reserve a pool of addresses for its use, the host macvlan network (default name macvlan0) named by PARAM_VLAN_NAME in the function execute_create_macvlan only needs a new host address to attach to this interface in order for it to communicate with containers attached to synology-pihole_macvlan. Hence this patch introduces a new parameter (--host-ip | HOST_IP | PARAM_HOST_IP) to allow the user to specify an address for this purpose, otherwise a reasonable address is attempted.

In the process of writing the patch a number of other changes were made, notably:

  The is_valid_cidr function variable CIDR_REGEX (line 168) - removed '([^0-9.]|$)' from the end of the regex because its purpose was unknown and did not seem to affect its function.

  Edits to the Usage instructions were made to try and clarify parameter usage.

  The parameter validation/initialisation functions were edited to allow a broader range of valid user configurations and to not consume more address space than necessary.
